### PR TITLE
Fix "View On Explorer" link from within the desktop electron wallet

### DIFF
--- a/src-electron/main-process/modules/backend.js
+++ b/src-electron/main-process/modules/backend.js
@@ -242,7 +242,7 @@ export class Backend {
 
         let path = null;
         if (params.type === "tx") {
-          path = "tx?tx_info=";
+          path = "tx.html?hash=";
         } else if (params.type === "service_node") {
           path = "service_node";
         }


### PR DESCRIPTION
Currently the link is "tx?tx_info=", it needs to be "tx.html?hash=", otherwise it is causing a 500 on the explorer.

Example: link generated from wallet currently: https://explorer.scalaproject.io/tx?tx_info=f5d67c8abf4998fa896e2c98c4c991d991986d003e51e1898a03bd80560623cf

Link generated with this fix: https://explorer.scalaproject.io/tx.html?hash=f5d67c8abf4998fa896e2c98c4c991d991986d003e51e1898a03bd80560623cf